### PR TITLE
Copilot/fix assert form error warning

### DIFF
--- a/packing_list/tests/test_views.py
+++ b/packing_list/tests/test_views.py
@@ -76,7 +76,7 @@ class ActivityViewTests(TestCase):
         # POST invalid
         r2 = self.client.post(reverse("packing_list:activity_create"), {"name": ""})
         self.assertEqual(r2.status_code, 200)
-        self.assertFormError(r2, "form", "name", "This field is required.")
+        self.assertFormError(r2.context["form"], "name", "This field is required.")
 
         # POST valid
         r3 = self.client.post(
@@ -99,7 +99,7 @@ class ActivityViewTests(TestCase):
         # POST invalid
         r2 = self.client.post(url, {"name": ""})
         self.assertEqual(r2.status_code, 200)
-        self.assertFormError(r2, "form", "name", "This field is required.")
+        self.assertFormError(r2.context["form"], "name", "This field is required.")
 
         # POST valid
         r3 = self.client.post(url, {"name": "Upd", "description": "d"})
@@ -194,7 +194,7 @@ class ItemViewTests(TestCase):
         # POST invalid
         r2 = self.client.post(url, {"name": ""})
         self.assertEqual(r2.status_code, 200)
-        self.assertFormError(r2, "form", "name", "This field is required.")
+        self.assertFormError(r2.context["form"], "name", "This field is required.")
 
         # POST valid
         data = {
@@ -233,7 +233,7 @@ class ItemViewTests(TestCase):
         self.assertEqual(self.item.name, "X2")
 
         r3 = self.client.post(url, {"name": ""})
-        self.assertFormError(r3, "form", "name", "This field is required.")
+        self.assertFormError(r3.context["form"], "name", "This field is required.")
 
     def test_delete_get_and_post(self):
         url = reverse("packing_list:item_delete", kwargs={"pk": self.item.pk})


### PR DESCRIPTION
What I changed
Updated 4 deprecated assertions from:

self.assertFormError(response, "form", "name", "This field is required.")
to:

self.assertFormError(response.context["form"], "name", "This field is required.")
Affected tests:

ActivityViewTests::test_create_get_and_post
ActivityViewTests::test_update_get_and_post
ItemViewTests::test_create_get_and_post
ItemViewTests::test_update_get_and_post
Validation run
pytest -q packing_list/tests/test_views.py → 17 passed, warnings removed
pytest -q packing_list/tests → 64 passed
parallel_validation (Code Review + CodeQL) → no issues
Notes
I also checked GitHub Actions runs/logs for the branch; there were no failed jobs.